### PR TITLE
Add missing deps for dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 ```
 
-3. Install dependencies:
+3. Install dependencies (includes optional visualization and reporting packages):
 ```bash
 pip install -r requirements.txt
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,9 +50,17 @@ arch==6.3.0
 pyfolio==0.9.2
 empyrical==0.5.5
 
+# Optimization
+cvxopt==1.3.2
+
 # Visualization
 dash==2.14.2
 dash-bootstrap-components==1.5.0
+altair==5.1.1
+vega_datasets==0.9.0
+pydeck==0.8.0
+folium==0.15.1
+wordcloud==1.9.2
 
 # Web framework
 fastapi==0.109.0
@@ -67,6 +75,11 @@ pytest-asyncio==0.23.2
 # Documentation
 sphinx==7.2.6
 sphinx-rtd-theme==2.0.0
+
+# Reporting
+pdfkit==1.0.0
+jinja2==3.1.2
+xlsxwriter==3.1.9
 
 # Development
 pre-commit==3.6.0


### PR DESCRIPTION
## Summary
- pin optional visualization/reporting packages in requirements
- note in README that requirements include extra packages

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b8a13c65483299a7856c82c58996f