### PR TITLE
Implement ModelUpdater and tests

### DIFF
--- a/tests/unit/test_model_updater.py
+++ b/tests/unit/test_model_updater.py
@@ -1,0 +1,45 @@
+import torch
+import json
+from trading.agents.updater import ModelUpdater
+from trading.models.advanced.ensemble.ensemble_model import EnsembleForecaster
+from trading.memory import PerformanceMemory
+
+
+class DummyModel:
+    """Simple model returning zeros."""
+
+    def __init__(self, config=None):
+        self.config = config or {}
+
+    def __call__(self, x):
+        return torch.zeros(x.shape[0], 1)
+
+
+def create_ensemble(tmp_path):
+    memory_path = tmp_path / "perf.json"
+    perf_mem = PerformanceMemory(str(memory_path))
+    config = {
+        'models': [
+            {'class': DummyModel},
+            {'class': DummyModel}
+        ],
+        'memory_path': str(memory_path)
+    }
+    model = EnsembleForecaster(config=config)
+    return model, perf_mem
+
+
+def test_weights_update_with_new_metrics(tmp_path):
+    model, perf_mem = create_ensemble(tmp_path)
+    updater = ModelUpdater(model, perf_mem)
+
+    initial = model.model_weights.clone()
+
+    perf_mem.update('AAPL', 'model_0', {'mse': 0.5, 'sharpe': 1.0})
+    perf_mem.update('AAPL', 'model_1', {'mse': 0.1, 'sharpe': 2.0})
+
+    updater.update_model_weights('AAPL', 'mse')
+
+    updated = model.model_weights
+    assert not torch.allclose(initial, updated)
+

--- a/trading/__init__.py
+++ b/trading/__init__.py
@@ -22,6 +22,7 @@ from .portfolio import PortfolioManager
 from .risk import RiskManager
 from .utils import LogManager, ModelLogger, DataLogger, PerformanceLogger
 from .memory import PerformanceMemory
+from .agents.updater import ModelUpdater
 from .nlp import NLInterface, PromptProcessor, ResponseFormatter, LLMProcessor
 from .market import MarketData, MarketIndicators
 from .evaluation import ModelEvaluator, RegressionMetrics, ClassificationMetrics, TimeSeriesMetrics, RiskMetrics
@@ -76,3 +77,4 @@ if OPTIMIZATION_AVAILABLE:
     __all__.append('DQNStrategyOptimizer')
 
 __all__.append('PerformanceMemory')
+__all__.append('ModelUpdater')

--- a/trading/agents/updater.py
+++ b/trading/agents/updater.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Optional
+
+from trading.models.advanced.ensemble.ensemble_model import EnsembleForecaster
+from trading.memory import PerformanceMemory
+
+
+class ModelUpdater:
+    """Periodically update ensemble model weights based on stored metrics."""
+
+    def __init__(self, model: EnsembleForecaster, memory: Optional[PerformanceMemory] = None, interval: int = 60):
+        self.model = model
+        self.memory = memory or PerformanceMemory()
+        self.interval = interval
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def update_model_weights(self, ticker: str, metric: str = "mse") -> None:
+        """Update model weights using the specified metric."""
+        self.model.update_weights_from_memory(ticker, metric)
+
+    def start_periodic_updates(self, ticker: str, metric: str = "mse") -> None:
+        """Start background updates of model weights."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, args=(ticker, metric), daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop periodic updates."""
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join()
+
+    def _run(self, ticker: str, metric: str) -> None:
+        while not self._stop_event.is_set():
+            self.update_model_weights(ticker, metric)
+            time.sleep(self.interval)
+


### PR DESCRIPTION
## Summary
- introduce `ModelUpdater` for updating ensemble weights from `PerformanceMemory`
- expose `ModelUpdater` in package init
- add unit test verifying weight update behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b8a15296c83299b058e673fd8f42b