### PR TITLE
Fix summary for small datasets

### DIFF
--- a/tests/unit/test_market_summary.py
+++ b/tests/unit/test_market_summary.py
@@ -1,0 +1,46 @@
+import pandas as pd
+from trading.analysis.market_analyzer import MarketAnalyzer
+
+
+def _make_df(length: int) -> pd.DataFrame:
+    dates = pd.date_range(start="2024-01-01", periods=length, freq="D")
+    values = range(1, length + 1)
+    data = {
+        "Open": values,
+        "High": [v + 1 for v in values],
+        "Low": [v - 1 for v in values],
+        "Close": values,
+        "Volume": [100] * length,
+    }
+    return pd.DataFrame(data, index=dates)
+
+
+def test_market_summary_single_row():
+    ma = MarketAnalyzer()
+    ma.data["TEST"] = _make_df(1)
+    ma.indicators["TEST"] = ma.data["TEST"]  # minimal indicators
+    summary = ma.get_market_summary("TEST")
+    assert summary is not None
+    assert summary["price"]["daily_change"] is None
+    assert summary["price"]["weekly_change"] is None
+    assert summary["price"]["monthly_change"] is None
+
+
+def test_market_summary_short_data():
+    ma = MarketAnalyzer()
+    ma.data["TEST"] = _make_df(3)
+    ma.indicators["TEST"] = ma.data["TEST"]
+    summary = ma.get_market_summary("TEST")
+    assert summary["price"]["daily_change"] == 1
+    assert summary["price"]["weekly_change"] == 2
+    assert summary["price"]["monthly_change"] == 2
+
+
+def test_market_summary_medium_data():
+    ma = MarketAnalyzer()
+    ma.data["TEST"] = _make_df(10)
+    ma.indicators["TEST"] = ma.data["TEST"]
+    summary = ma.get_market_summary("TEST")
+    assert summary["price"]["daily_change"] == 1
+    assert summary["price"]["weekly_change"] == 5
+    assert summary["price"]["monthly_change"] == 9

--- a/trading/analysis/market_analyzer.py
+++ b/trading/analysis/market_analyzer.py
@@ -463,17 +463,25 @@ class MarketAnalyzer:
                 raise MarketAnalysisError(f"No data available for {symbol}")
             
             data = self.data[symbol]
+
+            if data.empty:
+                return None
+
             latest = data.iloc[-1]
-            
-            # Calculate price changes
-            daily_change = latest['Close'] - data.iloc[-2]['Close']
-            daily_change_pct = (daily_change / data.iloc[-2]['Close']) * 100
-            
-            weekly_change = latest['Close'] - data.iloc[-6]['Close']
-            weekly_change_pct = (weekly_change / data.iloc[-6]['Close']) * 100
-            
-            monthly_change = latest['Close'] - data.iloc[-21]['Close']
-            monthly_change_pct = (monthly_change / data.iloc[-21]['Close']) * 100
+
+            def _calc_change(lookback: int) -> Tuple[Optional[float], Optional[float]]:
+                if len(data) < 2:
+                    return None, None
+
+                index = -lookback if len(data) >= lookback else 0
+                prev_close = data.iloc[index]['Close']
+                change = latest['Close'] - prev_close
+                pct = (change / prev_close) * 100
+                return float(change), float(pct)
+
+            daily_change, daily_change_pct = _calc_change(2)
+            weekly_change, weekly_change_pct = _calc_change(6)
+            monthly_change, monthly_change_pct = _calc_change(21)
             
             summary = {
                 'price': {


### PR DESCRIPTION
## Summary
- handle short lookback periods in market analyzer
- add tests for computing summaries on small datasets

## Testing
- `pytest -q tests/unit/test_market_summary.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c31471528832983f5867328e7e081