### PR TITLE
Handle missing volatility history

### DIFF
--- a/tests/trading/test_market_analyzer.py
+++ b/tests/trading/test_market_analyzer.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import numpy as np
+from trading.market.market_analyzer import MarketAnalyzer
+
+
+def test_volatility_trend_unknown_with_insufficient_history():
+    analyzer = MarketAnalyzer()
+    dates = pd.date_range(start='2024-01-01', periods=10, freq='D')
+    data = pd.DataFrame({'Close': np.random.rand(10) + 100}, index=dates)
+    result = analyzer.analyze_volatility(data)
+    assert result['volatility_trend'] == 'unknown'
+
+
+def test_volatility_trend_calculated_with_sufficient_history():
+    analyzer = MarketAnalyzer()
+    dates = pd.date_range(start='2024-01-01', periods=260, freq='D')
+    data = pd.DataFrame({'Close': np.random.rand(260) + 100}, index=dates)
+    result = analyzer.analyze_volatility(data)
+    assert result['volatility_trend'] in ['increasing', 'decreasing']

--- a/trading/market/market_analyzer.py
+++ b/trading/market/market_analyzer.py
@@ -94,7 +94,12 @@ class MarketAnalyzer:
             volatility_rank = (current_volatility - historical_volatility.min()) / (historical_volatility.max() - historical_volatility.min())
             
             # Calculate volatility trend
-            volatility_trend = 'increasing' if current_volatility > historical_volatility.iloc[-2] else 'decreasing'
+            hv_non_null = historical_volatility.dropna()
+            if len(hv_non_null) > 1:
+                prev_volatility = hv_non_null.iloc[-2]
+                volatility_trend = 'increasing' if current_volatility > prev_volatility else 'decreasing'
+            else:
+                volatility_trend = 'unknown'
             
             return {
                 'current_volatility': current_volatility,


### PR DESCRIPTION
## Summary
- guard against insufficient historical volatility data in `MarketAnalyzer`
- return `unknown` when volatility trend cannot be calculated
- add tests for the new branch

## Testing
- `python -m pytest tests/trading/test_market_analyzer.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c314947ac8329bfca12524b7d1627