### PR TITLE
Fix ensemble configs immutability

### DIFF
--- a/tests/unit/test_ensemble_model.py
+++ b/tests/unit/test_ensemble_model.py
@@ -48,3 +48,18 @@ class TestEnsembleModel(BaseModelTest):
         width_90 = (preds_90['upper'] - preds_90['lower']).mean().item()
 
         assert width_95 > width_90
+
+    def test_original_configs_not_modified(self):
+        """Ensure model configs remain unchanged after initialization."""
+
+        class DummyModel:
+            def __init__(self, config=None):
+                self.config = config or {}
+
+        configs = [
+            {'class': DummyModel, 'id': 1},
+            {'class': DummyModel, 'id': 2},
+        ]
+        original = [dict(c) for c in configs]
+        EnsembleForecaster(config={'models': configs})
+        assert configs == original

--- a/trading/models/advanced/ensemble/ensemble_model.py
+++ b/trading/models/advanced/ensemble/ensemble_model.py
@@ -7,7 +7,12 @@ from trading.models.base_model import BaseModel
 from trading.memory.performance_memory import PerformanceMemory
 
 class EnsembleForecaster(BaseModel):
-    """Ensemble model that combines predictions from multiple models."""
+    """Ensemble model that combines predictions from multiple models.
+
+    The configuration passed at initialization is treated as immutable. Each
+    entry in ``config['models']`` is copied internally so the original
+    dictionaries remain unchanged after the ensemble is created.
+    """
     
     def __init__(self, config: Optional[Dict[str, Any]] = None):
         """Initialize ensemble model.
@@ -39,8 +44,9 @@ class EnsembleForecaster(BaseModel):
         """Setup the ensemble model architecture."""
         self.models = []
         for model_config in self.config['models']:
-            model_class = model_config.pop('class')
-            model = model_class(config=model_config)
+            cfg = dict(model_config)
+            model_class = cfg.pop('class')
+            model = model_class(config=cfg)
             self.models.append(model)
         
         # Initialize model weights


### PR DESCRIPTION
## Summary
- avoid mutating each model configuration when building `EnsembleForecaster`
- document config immutability in `EnsembleForecaster`
- test that original model configs remain unchanged

## Testing
- `pytest tests/unit/test_ensemble_model.py::TestEnsembleModel::test_original_configs_not_modified -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c314a9b5883299f4f730f825e77c8