### PR TITLE
Implement partial tasks from review

### DIFF
--- a/tests/unit/test_normalize_indicator_name.py
+++ b/tests/unit/test_normalize_indicator_name.py
@@ -1,0 +1,10 @@
+import pytest
+from trading.utils.common import normalize_indicator_name
+
+@pytest.mark.parametrize("original,expected", [
+    ("macd 12-26-9", "MACD_12_26_9"),
+    ("RSI", "RSI"),
+    ("bollinger-band", "BOLLINGER_BAND"),
+])
+def test_normalize_indicator_name(original, expected):
+    assert normalize_indicator_name(original) == expected

--- a/trading/feature_engineering/feature_engineer.py
+++ b/trading/feature_engineering/feature_engineer.py
@@ -8,6 +8,7 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.decomposition import PCA
 from datetime import datetime, timedelta
 import logging
+from trading.utils.common import normalize_indicator_name
 
 logger = logging.getLogger(__name__)
 
@@ -238,6 +239,8 @@ class FeatureEngineer(FeatureEngineering):
 
         # Get all the technical indicators
         features = data.ta.indicators()
+        # Normalize indicator names for consistency
+        features.rename(columns=lambda c: normalize_indicator_name(c), inplace=True)
 
         # Apply user registered custom indicators
         for name, func in self.custom_indicators.items():

--- a/trading/utils/common.py
+++ b/trading/utils/common.py
@@ -306,4 +306,28 @@ def plot_rolling_metrics(metrics: pd.DataFrame):
     axes[1, 1].grid(True)
     
     plt.tight_layout()
-    plt.show() 
+    plt.show()
+
+
+def normalize_indicator_name(name: str) -> str:
+    """Normalize technical indicator names.
+
+    This helper converts indicator names to a consistent
+    ``UPPER_SNAKE_CASE`` style as commonly used by ``pandas_ta``.
+
+    Parameters
+    ----------
+    name:
+        Original indicator name.
+
+    Returns
+    -------
+    str
+        Normalized indicator name.
+    """
+
+    if not isinstance(name, str):
+        return str(name)
+
+    normalized = name.replace(" ", "_").replace("-", "_")
+    return normalized.upper()


### PR DESCRIPTION
## Summary
- add `normalize_indicator_name` helper
- use the helper in `FeatureEngineer`
- test indicator name normalization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c4714fd2c8329afa3d1a31f1b50d6