### PR TITLE
Enhance FeatureEngineer with custom indicators

### DIFF
--- a/tests/unit/test_feature_engineer_custom.py
+++ b/tests/unit/test_feature_engineer_custom.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import numpy as np
+from trading.feature_engineering import FeatureEngineer
+
+
+def create_data(rows: int = 30) -> pd.DataFrame:
+    dates = pd.date_range(start="2023-01-01", periods=rows, freq="D")
+    np.random.seed(0)
+    data = pd.DataFrame({
+        "open": np.random.uniform(100, 110, size=rows),
+        "high": np.random.uniform(110, 120, size=rows),
+        "low": np.random.uniform(90, 100, size=rows),
+        "close": np.random.uniform(100, 110, size=rows),
+        "volume": np.random.uniform(1e5, 1e6, size=rows),
+    }, index=dates)
+    return data
+
+
+def test_default_custom_indicators_registered():
+    fe = FeatureEngineer()
+    assert "ROLLING_ZSCORE" in fe.custom_indicators
+    assert "PRICE_RATIOS" in fe.custom_indicators
+
+
+def test_engineer_features_contains_custom_columns():
+    fe = FeatureEngineer()
+    data = create_data()
+    features = fe.engineer_features(data)
+    assert "ROLLING_ZSCORE" in features.columns
+    assert "PRICE_RATIOS_HL_RATIO" in features.columns
+    assert "PRICE_RATIOS_CO_RATIO" in features.columns

--- a/trading/feature_engineering/__init__.py
+++ b/trading/feature_engineering/__init__.py
@@ -1,3 +1,4 @@
 from .feature_engineer import FeatureEngineer
+from . import indicators
 
-__all__ = ['FeatureEngineer'] 
+__all__ = ["FeatureEngineer", "indicators"]

--- a/trading/feature_engineering/indicators.py
+++ b/trading/feature_engineering/indicators.py
@@ -1,0 +1,26 @@
+"""Common custom indicator functions for :mod:`feature_engineer`.
+
+This module provides a collection of helper functions that can be
+registered with :class:`FeatureEngineer` for additional feature
+calculations. Custom indicators are kept here to keep
+``feature_engineer.py`` focused on orchestration.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def rolling_zscore(series: pd.Series, window: int = 20) -> pd.Series:
+    """Calculate a rolling z-score for a series."""
+    mean = series.rolling(window=window).mean()
+    std = series.rolling(window=window).std()
+    return (series - mean) / std
+
+
+# Example indicator that returns multiple columns
+def price_ratios(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute high/low and close/open ratios."""
+    out = pd.DataFrame(index=df.index)
+    out["HL_RATIO"] = df["high"] / df["low"]
+    out["CO_RATIO"] = df["close"] / df["open"]
+    return out


### PR DESCRIPTION
## Summary
- add built-in custom indicators and modular indicator file
- improve FeatureEngineer error handling and verification
- expose indicators in `__init__`
- test default indicator registration and feature creation

## Testing
- `pytest -q tests/unit/test_feature_engineer_custom.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c48129b1883299e845ee58798f3d9