### PR TITLE
Implement config versioning

### DIFF
--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -274,4 +274,12 @@ class TestConfiguration:
         
         # Test file deletion
         config_manager.delete_config(str(config_path))
-        assert not config_path.exists() 
+        assert not config_path.exists()
+
+    def test_config_version_roundtrip(self, config_manager, model_config, tmp_path):
+        """Ensure version field is preserved when saving and loading."""
+        config_path = tmp_path / 'version_config.json'
+        config_manager.save_config(model_config, str(config_path))
+        loaded = config_manager.load_config(str(config_path))
+        assert isinstance(loaded, ModelConfig)
+        assert loaded.version == model_config.version


### PR DESCRIPTION
## Summary
- extend config loader to read from arbitrary paths and instantiate proper config classes
- add version field to config classes
- ensure tests handle version field

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c4a0f8ec083299d1221355375d253