### PR TITLE
Apply minor improvements from review tasks

### DIFF
--- a/tests/unit/test_common_returns.py
+++ b/tests/unit/test_common_returns.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import numpy as np
+from trading.utils.common import calculate_returns, calculate_sharpe_ratio
+
+
+def test_calculate_returns_log():
+    prices = pd.Series([1.0, 1.1, 1.21])
+    expected = np.log(prices / prices.shift(1))
+    pd.testing.assert_series_equal(calculate_returns(prices, method="log"), expected)
+
+
+def test_calculate_returns_simple():
+    prices = pd.Series([1.0, 1.1, 1.21])
+    expected = prices.pct_change()
+    pd.testing.assert_series_equal(calculate_returns(prices, method="simple"), expected)
+
+
+def test_calculate_sharpe_ratio():
+    returns = pd.Series([0.01, 0.02, -0.01, 0.005])
+    sr = calculate_sharpe_ratio(returns)
+    assert isinstance(sr, float)

--- a/trading/analysis/market_analyzer.py
+++ b/trading/analysis/market_analyzer.py
@@ -17,6 +17,8 @@ import logging
 from functools import wraps
 import time
 
+from trading.utils.common import normalize_indicator_name
+
 # Try to import redis, but make it optional
 try:
     import redis
@@ -339,6 +341,7 @@ class MarketAnalyzer:
             
             # Get all the technical indicators
             indicators = data.ta.indicators()
+            indicators.rename(columns=lambda c: normalize_indicator_name(c), inplace=True)
             
             # Add basic price-based features
             indicators['returns'] = data['Close'].pct_change()

--- a/trading/utils/common.py
+++ b/trading/utils/common.py
@@ -69,23 +69,40 @@ def load_config(config_path: Union[str, Path]) -> Dict[str, Any]:
     
     return config
 
-def save_config(config: Dict[str, Any], config_path: Union[str, Path]):
-    """Save configuration to file.
-    
-    Args:
-        config: Configuration dictionary
-        config_path: Path to save configuration
+def save_config(config: Dict[str, Any], config_path: Union[str, Path]) -> None:
+    """Save configuration to file with basic error handling.
+
+    Parameters
+    ----------
+    config : Dict[str, Any]
+        Configuration dictionary to persist.
+    config_path : Union[str, Path]
+        Path to the configuration file. Supported formats are ``.json`` and
+        ``.yaml``/``.yml``.
+
+    Raises
+    ------
+    IOError
+        If the file cannot be written.
+    ValueError
+        If the file extension is unsupported.
     """
+
     config_path = Path(config_path)
-    
-    if config_path.suffix == '.json':
-        with open(config_path, 'w') as f:
-            json.dump(config, f, indent=4)
-    elif config_path.suffix in ['.yaml', '.yml']:
-        with open(config_path, 'w') as f:
-            yaml.dump(config, f, default_flow_style=False)
-    else:
-        raise ValueError(f"Unsupported config file format: {config_path.suffix}")
+
+    try:
+        if config_path.suffix == ".json":
+            with open(config_path, "w") as f:
+                json.dump(config, f, indent=4)
+        elif config_path.suffix in [".yaml", ".yml"]:
+            with open(config_path, "w") as f:
+                yaml.dump(config, f, default_flow_style=False)
+        else:
+            raise ValueError(
+                f"Unsupported config file format: {config_path.suffix}"
+            )
+    except OSError as exc:
+        raise IOError(f"Failed to save config to {config_path}: {exc}") from exc
 
 def timer(func):
     """Decorator to measure function execution time."""


### PR DESCRIPTION
## Summary
- add basic error handling to `save_config`
- normalize indicator column names in `MarketAnalyzer`
- test common utility calculations

## Testing
- `pytest -q tests/unit/test_common_returns.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c5cf32ae0832988736031cdeccd2a